### PR TITLE
Remove bbs.ncku.edu.tw and add bbs.ccns.ncku.edu.tw

### DIFF
--- a/Targets
+++ b/Targets
@@ -24,6 +24,9 @@ host = bbs.cs.nthu.edu.tw
 ++ bbs_gamer_com_tw
 host = bbs.gamer.com.tw
 
+++ bbs_ccns_ncku_edu_tw
+host = bbs.ccns.ncku.edu.tw
+
 ++ bbs_nsysu_edu_tw
 host = bbs.nsysu.edu.tw
 

--- a/Targets
+++ b/Targets
@@ -24,9 +24,6 @@ host = bbs.cs.nthu.edu.tw
 ++ bbs_gamer_com_tw
 host = bbs.gamer.com.tw
 
-++ bbs_ncku_edu_tw
-host = bbs.ncku.edu.tw
-
 ++ bbs_nsysu_edu_tw
 host = bbs.nsysu.edu.tw
 


### PR DESCRIPTION
BBS maintained by Computer and Network Center, NCKU (成大計中BBS): bbs.ncku.edu.tw is officially closed.

Reference: (non-offical backuped announcement)
https://www.ptt.cc/bbs/sttmountain/M.1391313037.A.3F8.html

And 夢之大地(bbs.ccns.ncku.edu.tw) This BBS site is still alived and archive some historical discussion about campus and personal records.
And this site is relatively more representative for BBS in NCKU.